### PR TITLE
Apply change for Rails 5

### DIFF
--- a/lib/blinkers/params.rb
+++ b/lib/blinkers/params.rb
@@ -6,7 +6,7 @@ module Blinkers
 
     module InstanceMethods
       def secure_params(*sensitive_keys)
-        query = params.clone
+        query = params.clone.to_unsafe_h
 
         filter = ActionDispatch::Http::ParameterFilter.new(
           Rails.application.config.filter_parameters + sensitive_keys


### PR DESCRIPTION
### 概要

Rails5からActionController::ParametersがHashを継承しなくなったため､ to_unsafe_hを使って明示的にActionController::ParametersをHashへ変換するように変更しました｡

### 考慮した点

-  to_unsafe_hがRails4系でもActionController::Parametersに存在していることを確認しました

### 動作確認

- [ ] 本PRをローカルに落とす
- [ ] Rails4系でGemfileを下記のように編集し､paramsがFilterされることを確認
- [ ] Rails5系でGemfileを下記のように編集し､paramsがFilterされることを確認

```
gem 'blinkers', path: '../blinkers'
```